### PR TITLE
Fix include of SFML

### DIFF
--- a/SfmlLogoAnimation/SfmlLogoAnimation.hpp
+++ b/SfmlLogoAnimation/SfmlLogoAnimation.hpp
@@ -34,7 +34,7 @@
 #include <SFML/Window/Event.hpp>
 #include <SFML/Graphics/Texture.hpp>
 #include <SFML/Graphics/Sprite.hpp>
-#include <sfml/Audio/SoundBuffer.hpp>
+#include <SFML/Audio/SoundBuffer.hpp>
 #include <SFML/Audio/Sound.hpp>
 #include <SFML/System/Clock.hpp>
 #include <SFML/Window/Keyboard.hpp>


### PR DESCRIPTION
in `SfmlLogoAnimation.hpp` the SFML include path is invalid, so compiling does not work using a file-system which is case-sensitive (as ext4 etc).